### PR TITLE
Android devices causing TYPO3 error

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -288,7 +288,7 @@ class RedirectionMiddleware implements MiddlewareInterface
         /** @var SiteLanguage[] $siteLanguages */
         $siteLanguages = $site->getLanguages();
 
-        if ($normalizedParams->getHttpReferer()) {
+        if ($normalizedParams->getHttpReferer() && strpos($normalizedParams->getHttpReferer(), 'android-app') === false) {
             /** @var Uri $refererUri */
             $refererUri = GeneralUtility::makeInstance(Uri::class, $normalizedParams->getHttpReferer());
             /** @var string[] $siteLanguageBasePaths */


### PR DESCRIPTION
Since "TYPO3\CMS\Core\Http\Uri" in line 293 only supports "http" & "https" as scheme/protocol and no "android-app" when checking the referrer, you have to check additionally if the referrer begins with "android-app" before calling the function, because checking the referrer is unnecessary if you come from a app.