### PR TITLE
Add Google PageSpeed Insights to bot pattern

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -26,7 +26,7 @@ class RedirectionMiddleware implements MiddlewareInterface
     /**
      * @var string
      */
-    protected $botPattern = '/bot|google|baidu|bing|msn|teoma|slurp|yandex/i';
+    protected $botPattern = '/bot|google|baidu|bing|msn|teoma|slurp|yandex|Chrome-Lighthouse/i';
 
     /**
      * Adds an instance of TYPO3\CMS\Core\Http\NormalizedParams as


### PR DESCRIPTION
Avoid multiple page redirects for better performance score: Redirects introduce additional delays before the page can be loaded. (https://web.dev/redirects/)