### PR TITLE
Transfering the GET/POST parameters during redirection

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -180,13 +180,18 @@ class RedirectionMiddleware implements MiddlewareInterface
             return null;
         }
 
+        /** @var array $parameters Array in the form of: ['utm_source' => 'google', 'utm_medium' => 'social'] */
+        $parameters = $request->getQueryParams();
+
+        $parameters['_language'] = $matchingSiteLanguage;
+
         $uri = $site->getRouter()->generateUri(
             $pageArguments->getPageId(),
-            ['_language' => $matchingSiteLanguage]
+            $parameters
         );
 
         /** @var RedirectResponse $response */
-        $response = new RedirectResponse($uri, 302);
+        $response = new RedirectResponse($uri, 307);
         return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (time()+60*60*24*30));
     }
 
@@ -254,13 +259,18 @@ class RedirectionMiddleware implements MiddlewareInterface
                 return null;
             }
 
+            /** @var array $parameters Array in the form of: ['utm_source' => 'google', 'utm_medium' => 'social'] */
+            $parameters = $request->getQueryParams();
+
+            $parameters['_language'] = $matchingSiteLanguage;
+
             $uri = $site->getRouter()->generateUri(
                 $pageArguments->getPageId(),
-                ['_language' => $matchingSiteLanguage]
+                $parameters
             );
 
             /** @var RedirectResponse $response */
-            $response = new RedirectResponse($uri, 302);
+            $response = new RedirectResponse($uri, 307);
             return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (time()+60*60*24*30));
         } catch (\Throwable $e) {
             // IP address is not in database. Do not redirect.
@@ -342,11 +352,16 @@ class RedirectionMiddleware implements MiddlewareInterface
                 $preferredSiteLanguage = $site->getLanguageById($languageId);
 
                 if ($preferredSiteLanguage !== $requestLanguage) {
+                    /** @var array $parameters Array in the form of: ['utm_source' => 'google', 'utm_medium' => 'social'] */
+                    $parameters = $request->getQueryParams();
+
+                    $parameters['_language'] = $preferredSiteLanguage;
+
                     $uri = $site->getRouter()->generateUri(
                         $pageArguments->getPageId(),
-                        ['_language' => $preferredSiteLanguage]
+                        $parameters
                     );
-                    return new RedirectResponse($uri, 302);
+                    return new RedirectResponse($uri, 307);
                 }
             }
         }


### PR DESCRIPTION
So that advertising campaigns can also be tracked after language redirection e.g. "?utm_source=google&utm_medium=social&utm_campaign=promotion&utm_content=advertising"