### PR TITLE
Fix the value of the max age for cookie to 30days

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -83,6 +83,7 @@ class RedirectionMiddleware implements MiddlewareInterface
 
     /**
      * Returns redirect response based on users browser language.
+     * Sets the cookie for 30 days.
      *
      * @param ServerRequestInterface $request
      * @param string $cookieName
@@ -187,12 +188,12 @@ class RedirectionMiddleware implements MiddlewareInterface
 
         /** @var RedirectResponse $response */
         $response = new RedirectResponse($uri, 302);
-        return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (time()+60*60*24*30));
+        return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (60*60*24*30));
     }
 
     /**
      * Returns redirect response based on users IP address. GeoIP2 is used to
-     * get the country based on the visitors IP address.
+     * get the country based on the visitors IP address. Sets the cookie for 30 days.
      *
      * @param ServerRequestInterface $request
      * @param string $cookieName
@@ -261,7 +262,7 @@ class RedirectionMiddleware implements MiddlewareInterface
 
             /** @var RedirectResponse $response */
             $response = new RedirectResponse($uri, 302);
-            return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (time()+60*60*24*30));
+            return $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $matchingSiteLanguage->getLanguageId() . '; Path=/; Max-Age=' . (60*60*24*30));
         } catch (\Throwable $e) {
             // IP address is not in database. Do not redirect.
             return null;
@@ -269,7 +270,7 @@ class RedirectionMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Sets cookie with preferred language when user changes language in the frontend.
+     * Sets cookie with preferred language when user changes language in the frontend for 30 days.
      *
      * @param ServerRequestInterface $request
      * @param RequestHandlerInterface $handler
@@ -307,7 +308,7 @@ class RedirectionMiddleware implements MiddlewareInterface
                 strpos($refererUri->getPath(), $requestLanguage->getBase()->getPath()) !== 0 ||
                 ($requestLanguage->getBase()->getPath() === '/' && !in_array($requestLanguage->getBase()->getPath(), $siteLanguageBasePaths))
             ) {
-                $response = $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $requestLanguage->getLanguageId() . '; Path=/; Max-Age=' . (time()+60*60*24*30));
+                $response = $response->withAddedHeader('Set-Cookie', $cookieName . '=' . $requestLanguage->getLanguageId() . '; Path=/; Max-Age=' . (60*60*24*30));
             }
             return $response;
         }


### PR DESCRIPTION
Found a small issue in the RedirectionMiddleware, exactly the value of Max-Age for the cookie. The calculation adds the current time() to it, but Max-Age just wants a number of seconds. So I remove the PHP time() function and add comment for the timelife of the cookie.