### PR TITLE
Don't force redirection if language is defined in URL

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -51,6 +51,16 @@ class RedirectionMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
+        /**
+         * Do not redirect if URL has a language defined.
+         * Even better: Create an option if you want to force language if a language is defined in URL.
+         */
+        $languageId = $request->getAttribute('language')->getLanguageId();
+
+        if (($languageId !== null) && ($languageId !== 0)) {
+            return $handler->handle($request);
+        }
+
         $response = $this->setCookieOnLanguageChange($request, $handler, $cookieName);
         if ($response) {
             return $response;


### PR DESCRIPTION
We should include an option if we want to force a language, even if a language is defined in request URL.

Currently you can't open a Link for a different language - you are always redirected to your current language.