### PR TITLE
[BUGFIX] Avoid notices with PHP8

### DIFF
--- a/Classes/Middleware/RedirectionMiddleware.php
+++ b/Classes/Middleware/RedirectionMiddleware.php
@@ -107,7 +107,7 @@ class RedirectionMiddleware implements MiddlewareInterface
         $siteLanguages = $site->getLanguages();
 
         $siteLanguagesFallbacks = [];
-        if (is_array($site->getConfiguration()['SiteLanguageRedirectionFallbacks']) && !empty($site->getConfiguration()['SiteLanguageRedirectionFallbacks'])) {
+        if (is_array($site->getConfiguration()['SiteLanguageRedirectionFallbacks'] ?? null) && !empty($site->getConfiguration()['SiteLanguageRedirectionFallbacks'])) {
             $siteLanguagesFallbacks = $site->getConfiguration()['SiteLanguageRedirectionFallbacks'];
         }
 


### PR DESCRIPTION
Undefined array key "SiteLanguageRedirectionFallbacks" in `/var/www/html/app/site/public/typo3conf/ext/site_language_redirection/Classes/Middleware/RedirectionMiddleware.php` line 110